### PR TITLE
Update docs to include exit keybindings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,5 @@ Under the hood the dashboard utilizes SocketIO with a default port of `9838`. If
 
 #####`-eventdelay`
 This tunes the minimum threshold for reporting event loop delays. The default value is `10ms`. Any delay below this value will be reported at `0`.
+
+To gracefully exit and terminate the spawned process use one of:  `Ctrl + C`, `Q`, or `ESC`.


### PR DESCRIPTION
Small update to the docs just as the title says.

Closes: https://github.com/FormidableLabs/nodejs-dashboard/issues/5