### PR TITLE
Add support for node arguments

### DIFF
--- a/bin/nodejs-dashboard.js
+++ b/bin/nodejs-dashboard.js
@@ -4,6 +4,7 @@
 const SocketIO = require("socket.io");
 const spawn = require("cross-spawn");
 const commander = require("commander");
+const _ = require("lodash");
 const path = require("path");
 
 const Dashboard = require("../lib/dashboard");
@@ -26,7 +27,8 @@ if (!program.args.length) {
 }
 
 const command = program.args[0];
-const args = program.args.slice(1);
+const commandIndex = _.findIndex(program.rawArgs, (arg) => arg === command);
+const args = program.rawArgs.slice(commandIndex + 1);
 
 const port = program.port || config.PORT;
 const eventDelay = program.eventdelay || config.BLOCKED_THRESHOLD;


### PR DESCRIPTION
Currently commander is not including node arguments starting with "--" in it's 'args' array as well as any arguments provided after. 

When you supply a command such as `nodejs-dashboard node --harmony_destructuring server.js` commander ignores`--harmony_destructuring` and `server.js` entirely. The dashboard will launch but the application to monitor will not. 

There might be a more elegant way to get commander to pass the node arguments on to `args`. This does appear the intended functionality mentioned in a few issues such as [#442](https://github.com/tj/commander.js/pull/442).

This would close #6 