### PR TITLE
Fixed extra space in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ From within your `index.js` or app entry point simply require the `nodejs-dashbo
 
 ```
 require("nodejs-dashboard");
-
 ```
 
 #### Update your package.json


### PR DESCRIPTION
In the require ("nodejs-dashboard"); there was an extra space.