### PR TITLE
Chore readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ It's recommended that you create a npm script to launch the dashboard.
 ...
 ```
 
+If your app requires additional arguments you'll need to provide the `--` flag when launching the dashboard. For example:
+
+```
+...
+"scripts": {
+    "dev": "nodejs-dashboard -- node -myFlag=false --bar=true index.js"
+  }
+...
+```
+
+
 #### Launch your app
 Once you've completed these steps run the following in your terminal:
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Options:
   -e, --eventdelay [ms]  Minimum threshold for event loop reporting, default 10ms
 ```
 
-#####`-port`
+#####`--port`
 Under the hood the dashboard utilizes SocketIO with a default port of `9838`. If this conflicts with an existing service you can optionally change this value.
 
-#####`-eventdelay`
+#####`--eventdelay`
 This tunes the minimum threshold for reporting event loop delays. The default value is `10ms`. Any delay below this value will be reported at `0`.
 
 To gracefully exit and terminate the spawned process use one of:  `Ctrl + C`, `Q`, or `ESC`.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If your app requires additional arguments you'll need to pass the `--` flag to y
 
 ##### But I want to use something else to launch my app!
 
-Most CLI interfaces provide a mechanism for launching other tools. If you're looking to use another tool like [nodemon](https://github.com/remy/nodemon) or [babel](https://github.com/babel/babel/tree/master/packages/babel-cli) checkout the exec options provided by the cli.
+Most CLI interfaces provide a mechanism for launching other tools. If you're looking to use something like [nodemon](https://github.com/remy/nodemon) or [babel](https://github.com/babel/babel/tree/master/packages/babel-cli) checkout the exec options provided by the cli.
 
 `nodemon --exec "nodejs-dashboard babel-node" src/index.js`
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ If your app requires additional arguments you'll need to pass the `--` flag to y
 ...
 ```
 
+##### But I want to use something else to launch my app!
+
+Most CLI interfaces provide a mechanism for launching other tools. If you're looking to use another tool like [nodemon](https://github.com/remy/nodemon) or [babel](https://github.com/babel/babel/tree/master/packages/babel-cli) checkout the exec options provided by the cli.
+
+`nodemon --exec "nodejs-dashboard babel-node" src/index.js`
+
 
 #### Launch your app
 Once you've completed these steps run the following in your terminal:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ It's recommended that you create a npm script to launch the dashboard.
 ...
 ```
 
-If your app requires additional arguments you'll need to provide the `--` flag when launching the dashboard. For example:
+If your app requires additional arguments you'll need to pass the `--` flag to your script. For example:
 
 ```
 ...


### PR DESCRIPTION
Small update to readme to include example using `--` flag for passing args. 

Closes: https://github.com/FormidableLabs/nodejs-dashboard/issues/9, https://github.com/FormidableLabs/nodejs-dashboard/issues/22
