### PR TITLE
improve views positioning, rerender on screen resize

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -30,41 +30,94 @@ Dashboard.prototype.onEvent = function (event) {
   this.screen.render();
 };
 
-Dashboard.prototype._createView = function () {
-  // fixes weird scrolling issue
-  var container = blessed.box({});
-  this.screen.append(container);
+var stdOutHeight = 0.5;
+var stdOutWidth = 0.75;
 
+var metrics = [CpuView, EventLoopView, MemoryView];
+var metricsCount = metrics.length;
+
+var stdOutPosition = function (parent, interleave) {
+  return {
+    left: 0,
+    width: Math.ceil(parent.width * stdOutWidth),
+    top: 0,
+    height: interleave ? parent.height : Math.ceil(parent.height * stdOutHeight)
+  };
+};
+
+var stdErrPosition = function (parent) {
+  return {
+    left: 0,
+    width: Math.ceil(parent.width * stdOutWidth),
+    top: Math.ceil(parent.height * stdOutHeight),
+    height: "50%"
+  };
+};
+
+var metricsPosition = function (index, parent) {
+  var top = Math.ceil(index / metricsCount * parent.height);
+  var bottom = Math.ceil((index + 1) / metricsCount * parent.height);
+  return {
+    top: top,
+    height: bottom - top,
+    left: Math.ceil(parent.width * stdOutWidth),
+    width: Math.floor(parent.width * (1 - stdOutWidth))
+  };
+};
+
+Dashboard.prototype._logStream = function (streamView, data) {
+  var lines = data.replace(/\n$/, "");
+
+  streamView.onEvent(lines);
+};
+
+Dashboard.prototype._createStdoutView = function (container) {
   var stdoutView = new StreamView({
     parent: container,
     scrollback: this.options.scrollback,
     label: this.options.interleave ? "stdout / stderr" : "stdout",
     color: this.options.interleave ? "light-blue" : "green",
-    height: this.options.interleave ? "100%" : "50%"
+    getPosition: stdOutPosition
   });
 
-  this.eventPump.addListener("stdout", stdoutView.onEvent.bind(stdoutView));
+  this.eventPump.addListener("stdout", this._logStream.bind(this, stdoutView));
+};
 
-  var stderrView = stdoutView;
-
+Dashboard.prototype._createStderrView = function (container) {
   if (!this.options.interleave) {
-    stderrView = new StreamView({
+    var stderrView = new StreamView({
       parent: container,
       scrollback: this.options.scrollback,
       label: "stderr",
       color: "red",
-      top: "50%"
+      getPosition: stdErrPosition
     });
+
+    this.eventPump.addListener("stderr", this._logStream.bind(this, stderrView));
   }
+};
 
-  this.eventPump.addListener("stderr", stderrView.onEvent.bind(stderrView));
-
-  var metrics = [MemoryView, CpuView, EventLoopView];
-
-  _.each(metrics, function (Metric) {
-    var view = new Metric({ parent: this.screen });
+Dashboard.prototype._createMetricsViews = function (container) {
+  _.each(metrics, function (Metric, index) {
+    var view = new Metric({
+      parent: container,
+      getPosition: metricsPosition,
+      index: index
+    });
     this.eventPump.addListener("metrics", view.onEvent.bind(view));
   }.bind(this));
+};
+
+Dashboard.prototype._createView = function () {
+  // fixes weird scrolling issue
+  var container = blessed.box({});
+
+  this.screen.append(container);
+
+  this._createStdoutView(container);
+  this._createStderrView(container);
+
+  this._createMetricsViews(this.screen);
 
   this.screen.render();
 };

--- a/lib/views/cpu-view.js
+++ b/lib/views/cpu-view.js
@@ -8,6 +8,7 @@ var _ = require("lodash");
 var CpuView = function CpuView(options) {
   this.historyDepth = 10;
   this.cpuHistory = _.times(this.historyDepth, _.constant(0));
+  this.options = options;
 
   this.line = contrib.line({
     label: " cpu utilization ",
@@ -22,13 +23,11 @@ var CpuView = function CpuView(options) {
         fg: "cyan"
       }
     },
-    left: "75%",
-    height: "33%",
-    width: "25%",
     numYLabels: 4,
     maxY: 100,
     showLegend: false,
-    wholeNumbersOnly: true
+    wholeNumbersOnly: true,
+    position: options.getPosition(options.index, options.parent)
   });
 
   this.cpuStats = {
@@ -37,8 +36,18 @@ var CpuView = function CpuView(options) {
     y: this.cpuHistory
   };
 
+  options.parent.on("resize", this._onResize.bind(this));
+
   options.parent.append(this.line);
   this.line.setData(this.cpuStats);
+};
+
+CpuView.prototype._onResize = function () {
+  var options = this.options;
+
+  options.parent.remove(this.line);
+  this.line.position = options.getPosition(options.index, options.parent);
+  options.parent.append(this.line);
 };
 
 CpuView.prototype.onEvent = function (data) {

--- a/lib/views/eventloop-view.js
+++ b/lib/views/eventloop-view.js
@@ -5,9 +5,9 @@ var util = require("util");
 var _ = require("lodash");
 
 var EventLoopView = function EventLoopView(options) {
-
   this.historyDepth = 10;
   this.eventLoopHistory = _.times(this.historyDepth, _.constant(0));
+  this.options = options;
 
   this.line = contrib.line({
     label: " event loop delay ",
@@ -22,13 +22,10 @@ var EventLoopView = function EventLoopView(options) {
         fg: "cyan"
       }
     },
-    top: "33%",
-    left: "75%",
-    height: "33%",
-    width: "25%",
     numYLabels: 4,
     showLegend: false,
-    wholeNumbersOnly: true
+    wholeNumbersOnly: true,
+    position: options.getPosition(options.index, options.parent)
   });
 
   this.highwaterStats = {
@@ -49,8 +46,18 @@ var EventLoopView = function EventLoopView(options) {
     }
   };
 
+  options.parent.on("resize", this._onResize.bind(this));
+
   options.parent.append(this.line);
   this.line.setData([this.eventLoopStats, this.highwaterStats]);
+};
+
+EventLoopView.prototype._onResize = function () {
+  var options = this.options;
+
+  options.parent.remove(this.line);
+  this.line.position = options.getPosition(options.index, options.parent);
+  options.parent.append(this.line);
 };
 
 EventLoopView.prototype.onEvent = function (data) {

--- a/lib/views/memory-view.js
+++ b/lib/views/memory-view.js
@@ -6,8 +6,9 @@ var prettyBytes = require("pretty-bytes");
 var util = require("util");
 
 var MemoryView = function MemoryView(options) {
+  this.options = options;
 
-  var memoryFrame = blessed.box({
+  this.memoryFrame = blessed.box({
     label: " memory ",
     border: {
       type: "line"
@@ -20,11 +21,8 @@ var MemoryView = function MemoryView(options) {
         fg: "cyan"
       }
     },
-    top: "66%",
-    left: "75%",
-    height: "33%",
-    width: "25%",
-    showLabel: true
+    showLabel: true,
+    position: options.getPosition(options.index, options.parent)
   });
 
   this.heapGauge = contrib.gauge({
@@ -35,8 +33,6 @@ var MemoryView = function MemoryView(options) {
     },
     showLabel: true
   });
-
-  memoryFrame.append(this.heapGauge);
 
   this.heapText = blessed.text({
     content: "",
@@ -63,11 +59,22 @@ var MemoryView = function MemoryView(options) {
     showLabel: true
   });
 
-  memoryFrame.append(this.heapText);
-  memoryFrame.append(this.rssGauge);
-  memoryFrame.append(this.rssText);
+  options.parent.on("resize", this._onResize.bind(this));
 
-  options.parent.append(memoryFrame);
+  this.memoryFrame.append(this.heapGauge);
+  this.memoryFrame.append(this.heapText);
+  this.memoryFrame.append(this.rssGauge);
+  this.memoryFrame.append(this.rssText);
+
+  options.parent.append(this.memoryFrame);
+};
+
+MemoryView.prototype._onResize = function () {
+  var options = this.options;
+
+  options.parent.remove(this.memoryFrame);
+  this.memoryFrame.position = options.getPosition(options.index, options.parent);
+  options.parent.append(this.memoryFrame);
 };
 
 MemoryView.prototype._usageText = function (label, used, total) {

--- a/lib/views/stream-view.js
+++ b/lib/views/stream-view.js
@@ -7,8 +7,7 @@ var MAX_OBJECT_LOG_DEPTH = 20;
 
 var StreamView = function StreamView(options) {
 
-  this.scrollBox = blessed.log({
-    top: options.top || "0%",
+  var scrollBox = blessed.log({
     label: util.format(" %s ", options.label),
     scrollable: true,
     input: true,
@@ -20,9 +19,6 @@ var StreamView = function StreamView(options) {
     },
     keys: true,
     mouse: true,
-    left: "top",
-    width: "75%",
-    height: options.height || "50%",
     tags: true,
     border: {
       type: "line"
@@ -33,7 +29,14 @@ var StreamView = function StreamView(options) {
       border: {
         fg: options.color || "#f0f0f0"
       }
-    }
+    },
+    position: options.getPosition(options.parent, options.interleave)
+  });
+
+  this.scrollBox = scrollBox;
+
+  options.parent.on("resize", function () {
+    scrollBox.position = options.getPosition(options.parent, options.interleave);
   });
 
   options.parent.append(this.scrollBox);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "mocha -c --recursive test/**/*.spec.js",
+    "test:app": "./bin/nodejs-dashboard.js node test/app/index.js",
     "check": "npm run lint && npm test",
     "coverage": "istanbul cover --include-all-sources _mocha -- -c --recursive test/**/*.spec.js"
   },


### PR DESCRIPTION
* improve views positioning

Positioning with percentage doesn't work very well for arbitrary width/height. This fix calculates position manually and makes sure there are no gaps between views.

* ~~Optional statusbar view~~

~~This view shows lines from stdout or stderr that matches pattern defined with `--statuspattern` option. For example, it can be used for showing builder progress. Status view is visible only if `--statuspattern` is defined.~~

![image](https://cloud.githubusercontent.com/assets/790659/22585632/bde5074c-ea09-11e6-8167-ec533d64fec3.png)
