### PR TITLE
Test coverage

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 npm-debug.log
+coverage

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha --recursive ./test/**/*.spec.js"
+    "test": "mocha -c --recursive test/**/*.spec.js",
+    "check": "npm run lint && npm test",
+    "coverage": "istanbul cover --include-all-sources _mocha -- -c --recursive test/**/*.spec.js"
   },
   "repository": {
     "type": "git",
@@ -47,6 +49,7 @@
     "eslint-config-formidable": "^2.0.1",
     "eslint-plugin-filenames": "^1.1.0",
     "eslint-plugin-import": "^1.16.0",
+    "istanbul": "^0.4.5",
     "mocha": "^3.1.1",
     "sinon": "^1.17.6"
   }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -3,6 +3,7 @@
     "mocha":true
   },
   "rules": {
+    "max-nested-callbacks": [2, 5],
     "no-unused-expressions": 0
   }
 }

--- a/test/app/index.js
+++ b/test/app/index.js
@@ -1,5 +1,6 @@
-/* eslint-disable */
 "use strict";
+
+/* eslint-disable no-console, no-magic-numbers */
 
 require("../../index");
 
@@ -8,12 +9,11 @@ var _ = require("lodash");
 var slowFunc = function (count) {
   var begin = Date.now();
 
-  var values = _.times(count, function(n) { return _.random(0, count); });
+  var values = _.times(count, function () { return _.random(0, count); });
   values = _.sortBy(values);
 
   return Date.now() - begin;
-
-}
+};
 
 var bigBuffer = new Buffer(200000000);
 
@@ -25,7 +25,7 @@ setInterval(function () {
 
 setInterval(function () {
   console.log("Slow call started...");
-  var  duration = slowFunc(_.random(1000,100000));
+  var duration = slowFunc(_.random(1000, 100000));
   console.log("Completed in: ", duration);
 }, 3000);
 
@@ -33,8 +33,6 @@ setInterval(function () {
   console.log("Filling buffer...");
   bigBuffer.fill(2);
 }, 5000);
-
-
 
 setInterval(function () {
   console.error("bummer shoulda read the dox :(", new Error().stack);

--- a/test/lib/dashboard-agent.spec.js
+++ b/test/lib/dashboard-agent.spec.js
@@ -7,15 +7,18 @@ var SocketIO = require("socket.io");
 var config = require("../../lib/config");
 var dashboardAgent = require("../../lib/dashboard-agent");
 var pusage = require("pidusage");
+var tryCatch = require("../utils").tryCatch;
 
 describe("dashboard-agent", function () {
 
+  var sandbox;
   var server;
   var agent;
   var TEST_PORT = 12345;
   var MAX_EVENT_LOOP_DELAY = 10;
 
   before(function () {
+    sandbox = sinon.sandbox.create();
     process.env[config.PORT_KEY] = TEST_PORT;
     process.env[config.BLOCKED_THRESHOLD_KEY] = 1;
     process.env[config.REFRESH_INTERVAL_KEY] = 10;
@@ -26,26 +29,32 @@ describe("dashboard-agent", function () {
     server = new SocketIO(TEST_PORT);
   });
 
-  afterEach(function () {
-    server.close();
+  afterEach(function (done) {
     agent.destroy();
+    sandbox.restore();
+    server.close(done);
   });
 
   describe("initialization", function () {
 
     it("should use environment variables for configuration", function (done) {
       var checkMetrics = function (metrics) {
-        expect(metrics).to.be.exist;
+        expect(metrics).to.be.an("object");
         expect(metrics.eventLoop.delay).to.be.at.most(MAX_EVENT_LOOP_DELAY);
       };
 
       server.on("connection", function (socket) {
-        expect(socket).to.be.defined;
-        socket.on("error", done);
-        socket.on("metrics", function (data) { //eslint-disable-line max-nested-callbacks
-          socket.removeAllListeners("metrics");
-          checkMetrics(JSON.parse(data));
-          done();
+        try {
+          expect(socket).to.be.an("object");
+          socket.on("error", done);
+        } catch (err) {
+          done(err);
+        }
+        socket.on("metrics", function (data) {
+          tryCatch(done, function () {
+            socket.removeAllListeners("metrics");
+            checkMetrics(JSON.parse(data));
+          });
         });
       });
     });
@@ -55,9 +64,8 @@ describe("dashboard-agent", function () {
     it("should provide basic metrics", function (done) {
 
       var checkMetrics = function (metrics) {
-        expect(metrics).to.be.defined;
+        expect(metrics).to.be.an("object");
         expect(metrics.eventLoop).to.deep.equal({ delay: 0, high: 0 });
-        expect(metrics.mem).to.exist;
         expect(metrics.mem.systemTotal).to.be.above(0);
         expect(metrics.mem.rss).to.be.above(0);
         expect(metrics.mem.heapTotal).to.be.above(0);
@@ -66,43 +74,44 @@ describe("dashboard-agent", function () {
       };
 
       agent._getStats(function (err, metrics) {
-        expect(err).to.be.null;
-        checkMetrics(metrics);
-        done();
+        tryCatch(done, function () {
+          expect(err).to.be.null;
+          checkMetrics(metrics);
+        });
       });
     });
 
     it("should report an event loop delay and cpu stats", function (done) {
       var delay = { current: 100, max: 150 };
       var pusageResults = { cpu: 50 };
-      var pidStub = sinon.stub(pusage, "stat").yields(null, pusageResults);
+      sandbox.stub(pusage, "stat").yields(null, pusageResults);
 
       agent._delayed(delay.max);
       agent._delayed(delay.current);
 
       var checkMetrics = function (metrics) {
         expect(metrics.eventLoop.delay).to.equal(delay.current);
-        expect(metrics.eventLoop.high).to.be.equal(delay.max);
+        expect(metrics.eventLoop.high).to.equal(delay.max);
         expect(metrics.cpu.utilization).to.equal(pusageResults.cpu);
       };
 
       agent._getStats(function (err, metrics) {
-        expect(err).to.be.null;
-        checkMetrics(metrics);
-        pidStub.restore();
-        done();
+        tryCatch(done, function () {
+          expect(err).to.be.null;
+          checkMetrics(metrics);
+        });
       });
     });
 
     it("should return an error when pusage fails", function (done) {
-      var pidStub = sinon.stub(pusage, "stat").yields(new Error("bad error"));
+      sandbox.stub(pusage, "stat").yields(new Error("bad error"));
 
       agent._getStats(function (err, metrics) {
-        expect(err).to.exist;
-        expect(metrics).to.be.undefined;
-        expect(err.message).to.equal("bad error");
-        pidStub.restore();
-        done();
+        tryCatch(done, function () {
+          expect(err).to.exist;
+          expect(metrics).to.be.undefined;
+          expect(err.message).to.equal("bad error");
+        });
       });
     });
   });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,10 @@
+"use strict";
+
+exports.tryCatch = function (done, func) {
+  try {
+    func();
+    done();
+  } catch (err) {
+    done(err);
+  }
+};


### PR DESCRIPTION
- Enable test coverage using istanbul (`npm run coverage`)
- Shortcut script for lint + test (`npm run check`)
- Allow more deeply nested callbacks in tests
- Tweaks to existing tests:
  - Wrapped async test assertions in try/catch
  - Use sandbox and restore in `afterEach` in case test fails before reaching `restore()` line
  - Replaced a couple invalid assertions - `.to.be.defined` isn't a chai assertion but somehow doesn't throw an error

