### PR TITLE
Support multiple layouts

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -86,11 +86,12 @@ Dashboard.prototype._configureKeys = function () {
     this._showLayout(target);
   }.bind(this));
 
-  this.screen.key("?", this.views.help.node.toggle.bind(this.views.help.node));
+  var helpNode = this.views.help.node;
+  this.screen.key("?", helpNode.toggle.bind(helpNode));
 
   this.screen.key("escape", function () {
-    if (this.views.help.node.visible) {
-      this.views.help.node.hide();
+    if (helpNode.visible) {
+      helpNode.hide();
     } else {
       this._showLayout(0);
     }

--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -37,7 +37,7 @@ Dashboard.prototype._createViews = function () {
       scrollback: this.options.scrollback,
       events: ["stdout", "stderr"],
       color: "light-blue",
-      position: config.stdouterr.position
+      layoutConfig: config.stdouterr
     });
   } else {
     this.views.stdout = new StreamView({
@@ -45,32 +45,30 @@ Dashboard.prototype._createViews = function () {
       scrollback: this.options.scrollback,
       events: ["stdout"],
       color: "green",
-      position: config.stdout.position
+      layoutConfig: config.stdout
     });
     this.views.stderr = new StreamView({
       parent: this.container,
       scrollback: this.options.scrollback,
       events: ["stderr"],
       color: "red",
-      position: config.stderr.position
+      layoutConfig: config.stderr
     });
   }
 
   this.views.cpu = new CpuView({
     parent: this.container,
-    position: config.cpu.position,
-    limit: config.cpu.limit
+    layoutConfig: config.cpu
   });
 
   this.views.eventLoop = new EventLoopView({
     parent: this.container,
-    position: config.eventLoop.position,
-    limit: config.eventLoop.limit
+    layoutConfig: config.eventLoop
   });
 
   this.views.memory = new MemoryView({
     parent: this.container,
-    position: config.memory.position
+    layoutConfig: config.memory
   });
 
   this.views.help = new HelpView({
@@ -124,8 +122,8 @@ Dashboard.prototype._showLayout = function (id) {
     if (!view) {
       return;
     }
-    if (view.resize) {
-      view.resize(config.position, config.limit);
+    if (view.setLayout) {
+      view.setLayout(config);
     }
     view.node.show();
   }.bind(this));

--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -7,118 +7,129 @@ var StreamView = require("./views/stream-view");
 var EventLoopView = require("./views/eventloop-view");
 var MemoryView = require("./views/memory-view");
 var CpuView = require("./views/cpu-view");
-var EventEmitter = require("events");
+var HelpView = require("./views/help");
+var layouts = require("./layouts");
 
 var Dashboard = function Dashboard(options) {
   this.options = options || {};
+  this.views = {};
 
   this.screen = blessed.screen({
     smartCSR: true,
     title: options.appName
   });
 
-  this.screen.key(["escape", "q", "C-c"], function () {
-    process.exit(0); // eslint-disable-line no-process-exit
-  });
-
-  this.eventPump = new EventEmitter();
-  this._createView();
-};
-
-Dashboard.prototype.onEvent = function (event) {
-  this.eventPump.emit(event.type, event.data);
+  this._createViews();
+  this._configureKeys();
   this.screen.render();
 };
 
-var stdOutHeight = 0.5;
-var stdOutWidth = 0.75;
+Dashboard.prototype._createViews = function () {
+  var config = layouts[0];
 
-var metrics = [CpuView, EventLoopView, MemoryView];
-var metricsCount = metrics.length;
+  // container prevents stream view scrolling from interfering with side views
+  this.container = blessed.box();
+  this.screen.append(this.container);
 
-var stdOutPosition = function (parent, interleave) {
-  return {
-    left: 0,
-    width: Math.ceil(parent.width * stdOutWidth),
-    top: 0,
-    height: interleave ? parent.height : Math.ceil(parent.height * stdOutHeight)
-  };
-};
+  if (this.options.interleave) {
+    this.views.stdouterr = new StreamView({
+      parent: this.container,
+      scrollback: this.options.scrollback,
+      events: ["stdout", "stderr"],
+      color: "light-blue",
+      position: config.stdouterr.position
+    });
+  } else {
+    this.views.stdout = new StreamView({
+      parent: this.container,
+      scrollback: this.options.scrollback,
+      events: ["stdout"],
+      color: "green",
+      position: config.stdout.position
+    });
+    this.views.stderr = new StreamView({
+      parent: this.container,
+      scrollback: this.options.scrollback,
+      events: ["stderr"],
+      color: "red",
+      position: config.stderr.position
+    });
+  }
 
-var stdErrPosition = function (parent) {
-  return {
-    left: 0,
-    width: Math.ceil(parent.width * stdOutWidth),
-    top: Math.ceil(parent.height * stdOutHeight),
-    height: "50%"
-  };
-};
-
-var metricsPosition = function (index, parent) {
-  var top = Math.ceil(index / metricsCount * parent.height);
-  var bottom = Math.ceil((index + 1) / metricsCount * parent.height);
-  return {
-    top: top,
-    height: bottom - top,
-    left: Math.ceil(parent.width * stdOutWidth),
-    width: Math.floor(parent.width * (1 - stdOutWidth))
-  };
-};
-
-Dashboard.prototype._logStream = function (streamView, data) {
-  var lines = data.replace(/\n$/, "");
-
-  streamView.onEvent(lines);
-};
-
-Dashboard.prototype._createStdoutView = function (container) {
-  var stdoutView = new StreamView({
-    parent: container,
-    scrollback: this.options.scrollback,
-    label: this.options.interleave ? "stdout / stderr" : "stdout",
-    color: this.options.interleave ? "light-blue" : "green",
-    getPosition: stdOutPosition
+  this.views.cpu = new CpuView({
+    parent: this.container,
+    position: config.cpu.position,
+    limit: config.cpu.limit
   });
 
-  this.eventPump.addListener("stdout", this._logStream.bind(this, stdoutView));
+  this.views.eventLoop = new EventLoopView({
+    parent: this.container,
+    position: config.eventLoop.position,
+    limit: config.eventLoop.limit
+  });
+
+  this.views.memory = new MemoryView({
+    parent: this.container,
+    position: config.memory.position
+  });
+
+  this.views.help = new HelpView({
+    parent: this.container
+  });
+
+  this.currentLayout = 0;
 };
 
-Dashboard.prototype._createStderrView = function (container) {
-  if (!this.options.interleave) {
-    var stderrView = new StreamView({
-      parent: container,
-      scrollback: this.options.scrollback,
-      label: "stderr",
-      color: "red",
-      getPosition: stdErrPosition
-    });
+Dashboard.prototype._configureKeys = function () {
 
-    this.eventPump.addListener("stderr", this._logStream.bind(this, stderrView));
+  this.screen.key(["left", "right"], function (ch, key) {
+    var delta = key.name === "left" ? -1 : 1;
+    var target = (this.currentLayout + delta + layouts.length) % layouts.length;
+    this._showLayout(target);
+  }.bind(this));
+
+  this.screen.key("?", this.views.help.node.toggle.bind(this.views.help.node));
+
+  this.screen.key("escape", function () {
+    if (this.views.help.node.visible) {
+      this.views.help.node.hide();
+    } else {
+      this._showLayout(0);
+    }
+  }.bind(this));
+
+  this.screen.key(["q", "C-c"], function () {
+    process.exit(0); // eslint-disable-line no-process-exit
+  });
+};
+
+Dashboard.prototype.onEvent = function (event) {
+  this.screen.emit(event.type, event.data);
+  // avoid double screen render for stream events (Element calls screen.render on scroll)
+  // TODO dashboard shouldn't know which events are used by which widgets
+  if (event.type === "metrics") {
+    this.screen.render();
   }
 };
 
-Dashboard.prototype._createMetricsViews = function (container) {
-  _.each(metrics, function (Metric, index) {
-    var view = new Metric({
-      parent: container,
-      getPosition: metricsPosition,
-      index: index
-    });
-    this.eventPump.addListener("metrics", view.onEvent.bind(view));
+Dashboard.prototype._showLayout = function (id) {
+  if (this.currentLayout === id) {
+    return;
+  }
+  _.each(this.views, function (v) {
+    v.node.hide();
+  });
+  _.each(layouts[id], function (config, viewName) {
+    var view = this.views[viewName];
+    if (!view) {
+      return;
+    }
+    if (view.resize) {
+      view.resize(config.position, config.limit);
+    }
+    view.node.show();
   }.bind(this));
-};
-
-Dashboard.prototype._createView = function () {
-  // fixes weird scrolling issue
-  var container = blessed.box({});
-
-  this.screen.append(container);
-
-  this._createStdoutView(container);
-  this._createStderrView(container);
-
-  this._createMetricsViews(this.screen);
-
+  this.currentLayout = id;
   this.screen.render();
 };
 

--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -87,6 +87,11 @@ module.exports = [
       getPosition: function () {
         return { width: "100%", height: "100%" };
       }
+    },
+    stdouterr: {
+      getPosition: function () {
+        return { width: "100%", height: "100%" };
+      }
     }
   }
 ];

--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -1,42 +1,92 @@
 "use strict";
 
+/* eslint-disable no-magic-numbers */
+
+var LOG_HEIGHT = 0.5;
+var MEMORY_HEIGHT = 15;
+
+var getLogWidth = function (parent) {
+  return Math.floor(parent.width * 0.75);
+};
+
 // Each layout is an object of <view name>: <view config> pairs
 module.exports = [
   {
     stdout: {
-      position: { height: "50%", width: "75%" }
+      getPosition: function (parent) {
+        return {
+          height: Math.ceil(parent.height * LOG_HEIGHT),
+          width: getLogWidth(parent)
+        };
+      }
     },
     stderr: {
-      position: { top: "50%", width: "75%" }
+      getPosition: function (parent) {
+        return {
+          top: Math.ceil(parent.height * LOG_HEIGHT),
+          width: getLogWidth(parent)
+        };
+      }
     },
     stdouterr: {
-      position: { width: "75%" },
+      getPosition: function (parent) {
+        return {
+          width: getLogWidth(parent)
+        };
+      }
     },
     cpu: {
-      position: { top: 0, left: "75%", height: "33%", width: "25%" },
+      getPosition: function (parent) {
+        return {
+          left: getLogWidth(parent),
+          height: Math.floor((parent.height - MEMORY_HEIGHT) / 2)
+        };
+      },
       limit: 10
     },
     eventLoop: {
-      position: { top: "33%", left: "75%", height: "33%", width: "25%" },
+      getPosition: function (parent) {
+        return {
+          top: Math.floor((parent.height - MEMORY_HEIGHT) / 2),
+          left: getLogWidth(parent),
+          bottom: MEMORY_HEIGHT
+        };
+      },
       limit: 10
     },
     memory: {
-      position: { top: "66%", left: "75%", height: "33%", width: "25%" }
+      getPosition: function (parent) {
+        return {
+          left: getLogWidth(parent),
+          height: MEMORY_HEIGHT,
+          bottom: 0
+        };
+      }
     }
   },
   {
     cpu: {
-      position: { top: 0, height: "50%", width: "100%" },
+      getPosition: function (parent) {
+        return {
+          height: Math.ceil(parent.height / 2)
+        };
+      },
       limit: 30
     },
     eventLoop: {
-      position: { top: "50%", height: "50%", width: "100%" },
+      getPosition: function (parent) {
+        return {
+          top: Math.ceil(parent.height / 2)
+        };
+      },
       limit: 30
     }
   },
   {
     stdout: {
-      position: { width: "100%", height: "100%" }
+      getPosition: function () {
+        return { width: "100%", height: "100%" };
+      }
     }
   }
 ];

--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -1,0 +1,42 @@
+"use strict";
+
+// Each layout is an object of <view name>: <view config> pairs
+module.exports = [
+  {
+    stdout: {
+      position: { height: "50%", width: "75%" }
+    },
+    stderr: {
+      position: { top: "50%", width: "75%" }
+    },
+    stdouterr: {
+      position: { width: "75%" },
+    },
+    cpu: {
+      position: { top: 0, left: "75%", height: "33%", width: "25%" },
+      limit: 10
+    },
+    eventLoop: {
+      position: { top: "33%", left: "75%", height: "33%", width: "25%" },
+      limit: 10
+    },
+    memory: {
+      position: { top: "66%", left: "75%", height: "33%", width: "25%" }
+    }
+  },
+  {
+    cpu: {
+      position: { top: 0, height: "50%", width: "100%" },
+      limit: 30
+    },
+    eventLoop: {
+      position: { top: "50%", height: "50%", width: "100%" },
+      limit: 30
+    }
+  },
+  {
+    stdout: {
+      position: { width: "100%", height: "100%" }
+    }
+  }
+];

--- a/lib/views/base-line-graph.js
+++ b/lib/views/base-line-graph.js
@@ -34,6 +34,7 @@ BaseLineGraph.prototype.recalculatePosition = function () {
   // force line graph to re-render with new position
   this.parent.remove(this.node);
   this.parent.append(this.node);
+  this.node.setBack();
 };
 
 BaseLineGraph.prototype.setLayout = function (layoutConfig) {

--- a/lib/views/base-line-graph.js
+++ b/lib/views/base-line-graph.js
@@ -5,29 +5,41 @@ var contrib = require("blessed-contrib");
 var util = require("util");
 var _ = require("lodash");
 
+var BaseView = require("./base-view");
+
 var BaseLineGraph = function BaseLineGraph(options) {
-  _.each(["parent", "position", "limit", "label"], function (field) {
-    assert(options[field], util.format("BaseLineGraph requires %s option", field));
-    this[field] = options[field];
-  }.bind(this));
+  BaseView.call(this, options);
+
+  assert(options.label, "BaseLineGraph requires 'label' option");
+  this.label = options.label;
+
   this.unit = options.unit || "";
-  this.maxY = options.maxY;
   this.highwater = options.highwater;
 
-  this.maxLimit = this.limit;
-  this.values = _.times(this.limit, _.constant(0));
+  this.maxLimit = this.layoutConfig.limit;
+  this.values = _.times(this.layoutConfig.limit, _.constant(0));
 
-  this._createGraph();
+  this._createGraph(options);
   this.parent.screen.on("metrics", this.onEvent.bind(this));
 };
+
+Object.assign(BaseLineGraph.prototype, BaseView.prototype);
 
 BaseLineGraph.prototype.onEvent = function () {
   throw new Error("BaseLineGraph onEvent should be overwritten");
 };
 
-BaseLineGraph.prototype.resize = function (position, limit) {
-  this._setLimit(limit);
-  this._setPosition(position);
+BaseLineGraph.prototype.recalculatePosition = function () {
+  this.node.position = this.getPosition();
+  // force line graph to re-render with new position
+  this.parent.remove(this.node);
+  this.parent.append(this.node);
+};
+
+BaseLineGraph.prototype.setLayout = function (layoutConfig) {
+  this.layoutConfig = layoutConfig;
+  this._handleLimitChanged();
+  this.recalculatePosition();
 };
 
 // Should be called by child's onEvent handler
@@ -37,10 +49,10 @@ BaseLineGraph.prototype.update = function (value, highwater) {
   }
   this.values.push(value);
 
-  this.series.y = this.values.slice(-1 * this.limit);
+  this.series.y = this.values.slice(-1 * this.layoutConfig.limit);
 
   if (this.highwaterSeries) {
-    this.highwaterSeries.y = _.times(this.limit, _.constant(highwater));
+    this.highwaterSeries.y = _.times(this.layoutConfig.limit, _.constant(highwater));
     this.node.setLabel(util.format(" %s (%d%s), high (%d%s) ",
       this.label, value, this.unit, highwater, this.unit));
     this.node.setData([this.series, this.highwaterSeries]);
@@ -50,13 +62,17 @@ BaseLineGraph.prototype.update = function (value, highwater) {
   }
 };
 
-BaseLineGraph.prototype._createGraph = function () {
+BaseLineGraph.prototype._getXAxis = function () {
+  return _.reverse(_.times(this.layoutConfig.limit, String));
+};
+
+BaseLineGraph.prototype._createGraph = function (options) {
   this.node = contrib.line({
     label: util.format(" %s ", this.label),
     border: "line",
-    position: this.position,
+    position: this.getPosition(this.parent),
     numYLabels: 4,
-    maxY: this.maxY,
+    maxY: options.maxY,
     showLegend: false,
     wholeNumbersOnly: true,
     style: {
@@ -65,17 +81,16 @@ BaseLineGraph.prototype._createGraph = function () {
       }
     }
   });
-
-  var xAxis = _.reverse(_.times(this.limit, String));
+  this.parent.screen.log("set position for graph:", this.getPosition(this.parent));
 
   this.series = {
-    x: xAxis,
-    y: this.values.slice(-1 * this.limit)
+    x: this._getXAxis(),
+    y: this.values.slice(-1 * this.layoutConfig.limit)
   };
 
   if (this.highwater) {
     this.highwaterSeries = {
-      x: xAxis,
+      x: this.series.x,
       style: {
         line: "red"
       }
@@ -86,26 +101,21 @@ BaseLineGraph.prototype._createGraph = function () {
   this.node.setData([this.series]);
 };
 
-BaseLineGraph.prototype._setLimit = function (limit) {
-  if (!limit || limit === this.limit) {
+BaseLineGraph.prototype._handleLimitChanged = function () {
+  if (this.series.x.length === this.layoutConfig.limit) {
     return;
   }
-  if (limit > this.values.length) {
-    this.values = _.times(limit - this.values.length, _.constant(0)).concat(this.values);
-  }
-  this.limit = limit;
-  this.maxLimit = Math.max(limit, this.maxLimit);
-};
+  this.maxLimit = Math.max(this.layoutConfig.limit, this.maxLimit);
 
-BaseLineGraph.prototype._setPosition = function (position) {
-  if (!position || _.isEqual(position, this.position)) {
-    return;
+  this.series.x = this._getXAxis();
+  if (this.highwaterSeries) {
+    this.highwaterSeries.x = this.series.x;
   }
-  this.position = position;
-  // there's no way to resize line chart itself except to recreate it
-  // https://github.com/yaronn/blessed-contrib/issues/10
-  this.parent.remove(this.node);
-  this._createGraph();
+
+  if (this.layoutConfig.limit > this.values.length) {
+    var filler = _.times(this.layoutConfig.limit - this.values.length, _.constant(0));
+    this.values = filler.concat(this.values);
+  }
 };
 
 module.exports = BaseLineGraph;

--- a/lib/views/base-line-graph.js
+++ b/lib/views/base-line-graph.js
@@ -1,0 +1,111 @@
+"use strict";
+
+var assert = require("assert");
+var contrib = require("blessed-contrib");
+var util = require("util");
+var _ = require("lodash");
+
+var BaseLineGraph = function BaseLineGraph(options) {
+  _.each(["parent", "position", "limit", "label"], function (field) {
+    assert(options[field], util.format("BaseLineGraph requires %s option", field));
+    this[field] = options[field];
+  }.bind(this));
+  this.unit = options.unit || "";
+  this.maxY = options.maxY;
+  this.highwater = options.highwater;
+
+  this.maxLimit = this.limit;
+  this.values = _.times(this.limit, _.constant(0));
+
+  this._createGraph();
+  this.parent.screen.on("metrics", this.onEvent.bind(this));
+};
+
+BaseLineGraph.prototype.onEvent = function () {
+  throw new Error("BaseLineGraph onEvent should be overwritten");
+};
+
+BaseLineGraph.prototype.resize = function (position, limit) {
+  this._setLimit(limit);
+  this._setPosition(position);
+};
+
+// Should be called by child's onEvent handler
+BaseLineGraph.prototype.update = function (value, highwater) {
+  if (this.values.length >= this.maxLimit) {
+    this.values.shift();
+  }
+  this.values.push(value);
+
+  this.series.y = this.values.slice(-1 * this.limit);
+
+  if (this.highwaterSeries) {
+    this.highwaterSeries.y = _.times(this.limit, _.constant(highwater));
+    this.node.setLabel(util.format(" %s (%d%s), high (%d%s) ",
+      this.label, value, this.unit, highwater, this.unit));
+    this.node.setData([this.series, this.highwaterSeries]);
+  } else {
+    this.node.setLabel(util.format(" %s (%s%s) ", this.label, value, this.unit));
+    this.node.setData([this.series]);
+  }
+};
+
+BaseLineGraph.prototype._createGraph = function () {
+  this.node = contrib.line({
+    label: util.format(" %s ", this.label),
+    border: "line",
+    position: this.position,
+    numYLabels: 4,
+    maxY: this.maxY,
+    showLegend: false,
+    wholeNumbersOnly: true,
+    style: {
+      border: {
+        fg: "cyan"
+      }
+    }
+  });
+
+  var xAxis = _.reverse(_.times(this.limit, String));
+
+  this.series = {
+    x: xAxis,
+    y: this.values.slice(-1 * this.limit)
+  };
+
+  if (this.highwater) {
+    this.highwaterSeries = {
+      x: xAxis,
+      style: {
+        line: "red"
+      }
+    };
+  }
+
+  this.parent.append(this.node);
+  this.node.setData([this.series]);
+};
+
+BaseLineGraph.prototype._setLimit = function (limit) {
+  if (!limit || limit === this.limit) {
+    return;
+  }
+  if (limit > this.values.length) {
+    this.values = _.times(limit - this.values.length, _.constant(0)).concat(this.values);
+  }
+  this.limit = limit;
+  this.maxLimit = Math.max(limit, this.maxLimit);
+};
+
+BaseLineGraph.prototype._setPosition = function (position) {
+  if (!position || _.isEqual(position, this.position)) {
+    return;
+  }
+  this.position = position;
+  // there's no way to resize line chart itself except to recreate it
+  // https://github.com/yaronn/blessed-contrib/issues/10
+  this.parent.remove(this.node);
+  this._createGraph();
+};
+
+module.exports = BaseLineGraph;

--- a/lib/views/base-view.js
+++ b/lib/views/base-view.js
@@ -1,0 +1,28 @@
+"use strict";
+
+var assert = require("assert");
+
+var BaseView = function BaseView(options) {
+  assert(options.parent, "View requires parent");
+  assert(options.layoutConfig, "View requires layoutConfig option");
+
+  this.parent = options.parent;
+  this.layoutConfig = options.layoutConfig;
+
+  this.parent.screen.on("resize", this.recalculatePosition.bind(this));
+};
+
+BaseView.prototype.getPosition = function () {
+  return this.layoutConfig.getPosition(this.parent);
+};
+
+BaseView.prototype.recalculatePosition = function () {
+  this.node.position = this.getPosition();
+};
+
+BaseView.prototype.setLayout = function (layoutConfig) {
+  this.layoutConfig = layoutConfig;
+  this.node.position = this.getPosition();
+};
+
+module.exports = BaseView;

--- a/lib/views/cpu-view.js
+++ b/lib/views/cpu-view.js
@@ -1,66 +1,21 @@
 "use strict";
 
-var contrib = require("blessed-contrib");
-var util = require("util");
 var _ = require("lodash");
+var BaseLineGraph = require("./base-line-graph");
 
 
 var CpuView = function CpuView(options) {
-  this.historyDepth = 10;
-  this.cpuHistory = _.times(this.historyDepth, _.constant(0));
-  this.options = options;
-
-  this.line = contrib.line({
-    label: " cpu utilization ",
-    border: {
-      type: "line"
-    },
-    style: {
-      line: "yellow",
-      text: "green",
-      baseline: "black",
-      border: {
-        fg: "cyan"
-      }
-    },
-    numYLabels: 4,
-    maxY: 100,
-    showLegend: false,
-    wholeNumbersOnly: true,
-    position: options.getPosition(options.index, options.parent)
-  });
-
-  this.cpuStats = {
-    title: "utilization",
-    x: _.reverse(_.times(this.historyDepth, String)),
-    y: this.cpuHistory
-  };
-
-  options.parent.on("resize", this._onResize.bind(this));
-
-  options.parent.append(this.line);
-  this.line.setData(this.cpuStats);
+  BaseLineGraph.call(this, _.merge({
+    label: "cpu utilization",
+    unit: "%",
+    maxY: 100
+  }, options));
 };
 
-CpuView.prototype._onResize = function () {
-  var options = this.options;
-
-  options.parent.remove(this.line);
-  this.line.position = options.getPosition(options.index, options.parent);
-  options.parent.append(this.line);
-};
+CpuView.prototype = Object.create(BaseLineGraph.prototype);
 
 CpuView.prototype.onEvent = function (data) {
-
-  this.line.setLabel(util.format(" cpu utilization (%s) ", data.cpu.utilization.toFixed(1)));
-  this.cpuHistory.push(data.cpu.utilization);
-
-  if (this.cpuHistory.length > this.historyDepth) {
-    this.cpuHistory.shift();
-  }
-
-  this.line.setData([this.cpuStats]);
+  this.update(data.cpu.utilization.toFixed(1));
 };
-
 
 module.exports = CpuView;

--- a/lib/views/eventloop-view.js
+++ b/lib/views/eventloop-view.js
@@ -1,77 +1,20 @@
 "use strict";
 
-var contrib = require("blessed-contrib");
-var util = require("util");
 var _ = require("lodash");
+var BaseLineGraph = require("./base-line-graph");
 
 var EventLoopView = function EventLoopView(options) {
-  this.historyDepth = 10;
-  this.eventLoopHistory = _.times(this.historyDepth, _.constant(0));
-  this.options = options;
-
-  this.line = contrib.line({
-    label: " event loop delay ",
-    border: {
-      type: "line"
-    },
-    style: {
-      line: "yellow",
-      text: "green",
-      baseline: "black",
-      border: {
-        fg: "cyan"
-      }
-    },
-    numYLabels: 4,
-    showLegend: false,
-    wholeNumbersOnly: true,
-    position: options.getPosition(options.index, options.parent)
-  });
-
-  this.highwaterStats = {
-    title: "highwater",
-    x: _.reverse(_.times(this.historyDepth, String)),
-    y: this.eventLoopHistory,
-    style: {
-      line: "red"
-    }
-  };
-
-  this.eventLoopStats = {
-    title: "delay",
-    x: _.reverse(_.times(this.historyDepth, String)),
-    y: this.eventLoopHistory,
-    style: {
-      line: "yellow"
-    }
-  };
-
-  options.parent.on("resize", this._onResize.bind(this));
-
-  options.parent.append(this.line);
-  this.line.setData([this.eventLoopStats, this.highwaterStats]);
+  BaseLineGraph.call(this, _.merge({
+    label: "event loop delay",
+    highwater: true,
+    unit: "ms"
+  }, options));
 };
 
-EventLoopView.prototype._onResize = function () {
-  var options = this.options;
-
-  options.parent.remove(this.line);
-  this.line.position = options.getPosition(options.index, options.parent);
-  options.parent.append(this.line);
-};
+EventLoopView.prototype = Object.create(BaseLineGraph.prototype);
 
 EventLoopView.prototype.onEvent = function (data) {
-  var eventLoop = data.eventLoop;
-
-  this.highwaterStats.y = _.times(this.historyDepth, _.constant(eventLoop.high));
-  this.line.setLabel(util.format(" event loop delay (%dms), high (%dms) ", eventLoop.delay, eventLoop.high)); //eslint-disable-line
-  this.eventLoopHistory.push(eventLoop.delay);
-
-  if (this.eventLoopHistory.length > this.historyDepth) {
-    this.eventLoopHistory.shift();
-  }
-
-  this.line.setData([this.eventLoopStats, this.highwaterStats]);
+  this.update(data.eventLoop.delay, data.eventLoop.high);
 };
 
 module.exports = EventLoopView;

--- a/lib/views/help.js
+++ b/lib/views/help.js
@@ -40,13 +40,6 @@ var HelpView = function HelpView(options) {
   });
 
   options.parent.append(this.node);
-  options.parent.screen.on("prerender", function () {
-    // ensure help window always renders on top of other nodes
-    // doesn't work with history page if only called once
-    if (this.node.visible) {
-      this.node.setFront();
-    }
-  }.bind(this));
 };
 
 module.exports = HelpView;

--- a/lib/views/help.js
+++ b/lib/views/help.js
@@ -1,0 +1,52 @@
+"use strict";
+
+var blessed = require("blessed");
+
+var pkg = require("../../package.json");
+
+var HelpView = function HelpView(options) {
+  var content = [
+    "{center}{bold}keybindings{/bold}{/center}",
+    "",
+    "{cyan-fg} left, right{/}  rotate through layouts",
+    "{cyan-fg}         esc{/}  close popup window / return to default layout",
+    "{cyan-fg}           ?{/}  toggle this window",
+    "{cyan-fg}   ctrl-c, q{/}  quit",
+    "",
+    "{right}{gray-fg}version: " + pkg.version + "{/}"
+  ].join("\n");
+
+  this.node = blessed.box({
+    position: {
+      top: "center",
+      left: "center",
+      // using fixed numbers to support use of alignment tags
+      width: 64,
+      height: 10
+    },
+    border: "line",
+    padding: {
+      left: 1,
+      right: 1
+    },
+    style: {
+      border: {
+        fg: "white"
+      }
+    },
+    tags: true,
+    content: content,
+    hidden: true
+  });
+
+  options.parent.append(this.node);
+  options.parent.screen.on("prerender", function () {
+    // ensure help window always renders on top of other nodes
+    // doesn't work with history page if only called once
+    if (this.node.visible) {
+      this.node.setFront();
+    }
+  }.bind(this));
+};
+
+module.exports = HelpView;

--- a/lib/views/memory-view.js
+++ b/lib/views/memory-view.js
@@ -5,13 +5,16 @@ var contrib = require("blessed-contrib");
 var prettyBytes = require("pretty-bytes");
 var util = require("util");
 
+var BaseView = require("./base-view");
+
 var MAX_PERCENT = 100;
 
 var MemoryView = function MemoryView(options) {
+  BaseView.call(this, options);
 
   this.node = blessed.box({
     label: " memory ",
-    position: options.position,
+    position: this.getPosition(),
     border: "line",
     style: {
       border: {
@@ -29,6 +32,8 @@ var MemoryView = function MemoryView(options) {
   options.parent.append(this.node);
   options.parent.screen.on("metrics", this.onEvent.bind(this));
 };
+
+Object.assign(MemoryView.prototype, BaseView.prototype);
 
 MemoryView.prototype.onEvent = function (data) {
   var mem = data.mem;

--- a/lib/views/memory-view.js
+++ b/lib/views/memory-view.js
@@ -5,104 +5,51 @@ var contrib = require("blessed-contrib");
 var prettyBytes = require("pretty-bytes");
 var util = require("util");
 
-var MemoryView = function MemoryView(options) {
-  this.options = options;
+var MAX_PERCENT = 100;
 
-  this.memoryFrame = blessed.box({
+var MemoryView = function MemoryView(options) {
+
+  this.node = blessed.box({
     label: " memory ",
-    border: {
-      type: "line"
-    },
+    position: options.position,
+    border: "line",
     style: {
-      line: "yellow",
-      text: "green",
-      baseline: "black",
       border: {
         fg: "cyan"
       }
-    },
-    showLabel: true,
-    position: options.getPosition(options.index, options.parent)
-  });
-
-  this.heapGauge = contrib.gauge({
-    style: {
-      line: "yellow",
-      text: "green",
-      baseline: "black"
-    },
-    showLabel: true
-  });
-
-  this.heapText = blessed.text({
-    content: "",
-    padding: {
-      left: 1
     }
   });
 
-  this.rssText = blessed.text({
-    content: "",
-    top: "50%",
-    padding: {
-      left: 1
-    }
-  });
+  this.heapGauge = contrib.gauge({ label: "heap" });
+  this.node.append(this.heapGauge);
 
-  this.rssGauge = contrib.gauge({
-    style: {
-      line: "yellow",
-      text: "green",
-      baseline: "black"
-    },
-    top: "55%",
-    showLabel: true
-  });
+  this.rssGauge = contrib.gauge({ label: "resident", top: "50%" });
+  this.node.append(this.rssGauge);
 
-  options.parent.on("resize", this._onResize.bind(this));
-
-  this.memoryFrame.append(this.heapGauge);
-  this.memoryFrame.append(this.heapText);
-  this.memoryFrame.append(this.rssGauge);
-  this.memoryFrame.append(this.rssText);
-
-  options.parent.append(this.memoryFrame);
-};
-
-MemoryView.prototype._onResize = function () {
-  var options = this.options;
-
-  options.parent.remove(this.memoryFrame);
-  this.memoryFrame.position = options.getPosition(options.index, options.parent);
-  options.parent.append(this.memoryFrame);
-};
-
-MemoryView.prototype._usageText = function (label, used, total) {
-  return util.format("%s: %s / %s", label, prettyBytes(used), prettyBytes(total));
-};
-
-MemoryView.prototype._stackedPercents = function (used, total) {
-  var usedPercent = Math.floor(used / total * 100.0); //eslint-disable-line no-magic-numbers
-  var remainingPercent = 100 - usedPercent; //eslint-disable-line no-magic-numbers
-
-  return { usedPercent: usedPercent, remainingPercent: remainingPercent };
+  options.parent.append(this.node);
+  options.parent.screen.on("metrics", this.onEvent.bind(this));
 };
 
 MemoryView.prototype.onEvent = function (data) {
-
   var mem = data.mem;
-  var heapMetrics = this._stackedPercents(mem.heapUsed, mem.heapTotal);
-  var rssMetrics = this._stackedPercents(mem.rss, mem.systemTotal);
+  this.update(this.heapGauge, mem.heapUsed, mem.heapTotal);
+  this.update(this.rssGauge, mem.rss, mem.systemTotal);
+};
 
-  this.heapGauge.setStack([
-    { percent: heapMetrics.usedPercent, stroke: "red" },
-    { percent: heapMetrics.remainingPercent, stroke: "blue" }
-  ]);
+MemoryView.prototype.update = function (gauge, used, total) {
+  var percentUsed = Math.floor(used / total * MAX_PERCENT);
+  if (gauge === this.heapGauge) {
+    gauge.setStack([
+      { percent: percentUsed, stroke: "red" },
+      { percent: MAX_PERCENT - percentUsed, stroke: "blue" }
+    ]);
+  } else {
+    gauge.setPercent(percentUsed);
+  }
 
-  this.heapText.setContent(this._usageText("heap usage", mem.heapUsed, mem.heapTotal));
-
-  this.rssGauge.setPercent(rssMetrics.usedPercent);
-  this.rssText.setContent(this._usageText("resident", mem.rss, mem.systemTotal));
+  gauge.setLabel(
+    util.format("%s: %s / %s", gauge.options.label, prettyBytes(used), prettyBytes(total))
+  );
 };
 
 module.exports = MemoryView;

--- a/lib/views/stream-view.js
+++ b/lib/views/stream-view.js
@@ -4,15 +4,17 @@ var blessed = require("blessed");
 var util = require("util");
 var _ = require("lodash");
 
+var BaseView = require("./base-view");
+
 var MAX_OBJECT_LOG_DEPTH = 20;
 
 var StreamView = function StreamView(options) {
-  this.parent = options.parent;
+  BaseView.call(this, options);
 
   this.node = blessed.log({
     label: util.format(" %s ", options.events.join(" / ")),
 
-    position: options.position,
+    position: this.getPosition(),
 
     scrollable: true,
     alwaysScroll: true,
@@ -44,10 +46,7 @@ var StreamView = function StreamView(options) {
   }.bind(this));
 };
 
-StreamView.prototype.resize = function (position) {
-  this.node.position = position;
-  this.parent.render();
-};
+Object.assign(StreamView.prototype, BaseView.prototype);
 
 // this is to fix the Log's log/add method
 // the original method calls shiftLine with two parameters (start, end)

--- a/lib/views/stream-view.js
+++ b/lib/views/stream-view.js
@@ -40,10 +40,14 @@ var StreamView = function StreamView(options) {
   });
 
   this.parent.append(this.node);
-  var eventHandler = this.node.log.bind(this.node);
+  var eventHandler = this.log.bind(this);
   _.each(options.events, function (eventName) {
     this.parent.screen.on(eventName, eventHandler);
   }.bind(this));
+};
+
+StreamView.prototype.log = function (data) {
+  this.node.log(data.replace(/\n$/, ""));
 };
 
 Object.assign(StreamView.prototype, BaseView.prototype);

--- a/lib/views/stream-view.js
+++ b/lib/views/stream-view.js
@@ -2,48 +2,51 @@
 
 var blessed = require("blessed");
 var util = require("util");
+var _ = require("lodash");
 
 var MAX_OBJECT_LOG_DEPTH = 20;
 
 var StreamView = function StreamView(options) {
+  this.parent = options.parent;
 
-  var scrollBox = blessed.log({
-    label: util.format(" %s ", options.label),
+  this.node = blessed.log({
+    label: util.format(" %s ", options.events.join(" / ")),
+
+    position: options.position,
+
     scrollable: true,
-    input: true,
     alwaysScroll: true,
     scrollback: options.scrollback,
     scrollbar: {
-      ch: " ",
       inverse: true
     },
+
+    input: true,
     keys: true,
     mouse: true,
+
     tags: true,
-    border: {
-      type: "line"
-    },
+
+    border: "line",
     style: {
       fg: "white",
       bg: "black",
       border: {
         fg: options.color || "#f0f0f0"
       }
-    },
-    position: options.getPosition(options.parent, options.interleave)
+    }
   });
 
-  this.scrollBox = scrollBox;
-
-  options.parent.on("resize", function () {
-    scrollBox.position = options.getPosition(options.parent, options.interleave);
-  });
-
-  options.parent.append(this.scrollBox);
+  this.parent.append(this.node);
+  var eventHandler = this.node.log.bind(this.node);
+  _.each(options.events, function (eventName) {
+    this.parent.screen.on(eventName, eventHandler);
+  }.bind(this));
 };
 
-StreamView.prototype.onEvent = function (data) {
-  this.scrollBox.log(data);
+StreamView.prototype.resize = function (position) {
+  this.node.position = position;
+  this.parent.render();
 };
 
 // this is to fix the Log's log/add method


### PR DESCRIPTION
### Interface changes

Looks like this: [demo gif](http://g.recordit.co/G0AX9cYkIJ.gif)

- Memory view is now fixed height - since the gauges are fixed height it doesn't scale except for adding empty space between elements
- Three layouts: original (default), cpu & event loop, full-screen stdout
- Arrow keys rotate through layouts
- `?` key triggers popup

### Overview of code changes

- Layouts are defined with plain objects that specify which views to show and options (mainly positioning) for those views
  - Integrated changes from #51 so positions are methods that calculate based on parent size
- The dashboard creates all views on startup
  - Since they're all part of the default layout this works well - may need to adjust if that changes
- Dashboard hides/shows views on layout change
  - Hiding (rather than detaching) allows views to continue receiving data while hidden
- Reusing views instead of recreating preserves data when switching layouts
- `BaseView` abstracts a few common features of views
- `BaseLineGraph` adds a lot of line-graph-specific behavior for cpu and event loop views

### To do

- Tests (in progress, doing separate PR since there are so many changes in this one)
- There's some delay with the help window and line graphs - you can see graphs are slow to appear in the gif linked above. Will file an issue for that once this is merged (since it doesn't apply to current master)