### PR TITLE
fix log autoscroll disabling

### DIFF
--- a/lib/views/stream-view.js
+++ b/lib/views/stream-view.js
@@ -8,6 +8,29 @@ var BaseView = require("./base-view");
 
 var MAX_OBJECT_LOG_DEPTH = 20;
 
+// reapply scroll method override from Log
+// https://github.com/chjj/blessed/blob/master/lib/widgets/log.js#L69
+// which is broken by workaround in Element
+// https://github.com/chjj/blessed/blob/master/lib/widgets/element.js#L35
+//
+// this method prevents auto-scrolling to bottom if user scrolled the view up
+// blessed v0.1.81 - https://github.com/chjj/blessed/issues/284
+var fixLogScroll = function (log) {
+  var maxScrollPercent = 100;
+
+  log.scroll = function (offset, always) {
+    if (offset === 0) {
+      return this._scroll(offset, always);
+    }
+    this._userScrolled = true;
+    var ret = this._scroll(offset, always);
+    if (this.getScrollPerc() === maxScrollPercent) {
+      this._userScrolled = false;
+    }
+    return ret;
+  };
+};
+
 var StreamView = function StreamView(options) {
   BaseView.call(this, options);
 
@@ -38,6 +61,8 @@ var StreamView = function StreamView(options) {
       }
     }
   });
+
+  fixLogScroll(this.node);
 
   this.parent.append(this.node);
   var eventHandler = this.log.bind(this);


### PR DESCRIPTION
To reproduce: when log overflows the view, scroll it up - autoscroll should be disabled until view is scrolled down again.

I also added [issue](https://github.com/chjj/blessed/issues/284) in blessed repo (just in case).