### PR TITLE
BUG: Switch to underscore environment variables names

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,13 +1,17 @@
 "use strict";
 
 var pkg = require("../package.json");
+// Env var names must comply with:
+// http://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html
+// See: https://github.com/FormidableLabs/nodejs-dashboard/issues/75
+var name = pkg.name.replace("-", "_");
 
 module.exports = {
   PORT: 9838,
-  PORT_KEY: pkg.name + "_PORT",
+  PORT_KEY: name + "_PORT",
   REFRESH_INTERVAL: 1000,
-  REFRESH_INTERVAL_KEY: pkg.name + "_REFRESH_INTERVAL",
+  REFRESH_INTERVAL_KEY: name + "_REFRESH_INTERVAL",
   BLOCKED_THRESHOLD: 10,
-  BLOCKED_THRESHOLD_KEY: pkg.name + "_BLOCKED_THRESHOLD",
+  BLOCKED_THRESHOLD_KEY: name + "_BLOCKED_THRESHOLD",
   LAYOUTS: ""
 };


### PR DESCRIPTION
Fixes #75 

Can test out in: https://github.com/FormidableLabs/nodejs-dashboard-75-experiments (@jjasonclark -- I've pushed some updates to `env.js` and to depend on _this_ PR branch instead of from npm)

/cc @jasonwilson @jjasonclark 