### PR TITLE
Move customization to layout generation

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -20,7 +20,6 @@ var THROTTLE_TIMEOUT = 150;
 var Dashboard = function Dashboard(options) {
   this.options = options || {};
   this.views = {};
-  this.settings = options.settings;
 
   this.screen = blessed.screen({
     smartCSR: true,
@@ -36,7 +35,7 @@ var Dashboard = function Dashboard(options) {
 };
 
 Dashboard.prototype._createViews = function () {
-  this.layouts = generateLayouts(this.options.layoutsFile);
+  this.layouts = generateLayouts(this.options.layoutsFile, this.options.settings);
   this.views = [];
 
   // container prevents stream view scrolling from interfering with side views
@@ -156,11 +155,6 @@ Dashboard.prototype._showLayout = function (id) {
     }
 
     if (View) {
-      if (this.settings[layoutConfig.view.type]) {
-        layoutConfig = _.merge(layoutConfig, {
-          view: this.settings[layoutConfig.view.type]
-        });
-      }
       var view = new View({
         parent: this.container,
         logProvider: this.logProvider,

--- a/lib/generate-layouts.js
+++ b/lib/generate-layouts.js
@@ -129,14 +129,13 @@ var loadConfigs = function (layoutsFile) {
 
 var applyCustomizations = function (customizations) {
   return function (panelsConfig) {
-    var customized = panelsConfig.map(function (view) {
+    return panelsConfig.map(function (view) {
       var customization = customizations[view.type];
       if (!customization) {
         return view;
       }
       return _.merge(view, { view: customization });
     });
-    return customized;
   };
 };
 

--- a/lib/generate-layouts.js
+++ b/lib/generate-layouts.js
@@ -1,11 +1,11 @@
 "use strict";
+
 var _ = require("lodash");
 var assert = require("assert");
 var path = require("path");
 var defaultLayoutConfig = require("./default-layout-config");
 var validate = require("jsonschema").validate;
 var layoutConfigSchema = require("./layout-config-schema.json");
-/* eslint-disable no-magic-numbers */
 
 // Each layout consists of vertical panels, that contains its position and horizontal views.
 // Flex-like positions of panels and views defined by 'grow' and 'size' parameters.
@@ -108,7 +108,7 @@ var createLayout = function (panelsConfig) {
   }, []);
 };
 
-module.exports = function generateLayouts(layoutsFile) {
+var loadConfigs = function (layoutsFile) {
   var layoutConfig = defaultLayoutConfig;
   if (layoutsFile) {
     /* eslint-disable global-require */
@@ -124,6 +124,24 @@ module.exports = function generateLayouts(layoutsFile) {
       "Layout config is invalid:\n\n  * " + validationResult.errors.join("\n  * ") + "\n"
     );
   }
+  return layoutConfig;
+};
 
-  return layoutConfig.map(createLayout);
+var applyCustomizations = function (customizations) {
+  return function (panelsConfig) {
+    var customized = panelsConfig.map(function (view) {
+      var customization = customizations[view.type];
+      if (!customization) {
+        return view;
+      }
+      return _.merge(view, { view: customization });
+    });
+    return customized;
+  };
+};
+
+module.exports = function generateLayouts(layoutsFile, customizations) {
+  return loadConfigs(layoutsFile)
+    .map(applyCustomizations(customizations || {}))
+    .map(createLayout);
 };


### PR DESCRIPTION
Layouts can be customized via a settings file. Move code to apply this to the generate layout function. This make it so the panels config doesn't need to change during the program. 

This feature will be used in a future PR.