### PR TITLE
Send SIGINT on Ctrl+C instead of immediate exit

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -52,7 +52,7 @@ Dashboard.prototype._configureKeys = function () {
   // this key will be watched on the global screen
   this.screen.ignoreLocked = ["C-c"];
   this.screen.key("C-c", function () {
-    process.exit(0); // eslint-disable-line no-process-exit
+    process.kill(process.pid, "SIGINT");
   });
 
   // watch for key events on the main container; not the screen


### PR DESCRIPTION
For a process to have a change for a graceful shutdown a SIGINT signal is sent when Ctrl+C is pressed instead of exiting the process immediately.

Blessed already have a registered SIGINT handler which calls `process.exit(0)` if no other handlers exist (https://github.com/chjj/blessed/blob/master/lib/widgets/screen.js#L232)