### PR TITLE
Misc updates: global require, Ctrl-c + SIGINT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## UNRELEASED
+
+- **Fixed**: Support global installs of `nodejs-dashboard`. Add the `node_modules` directory from wherever `nodejs-dashboard` is installed to `NODE_PATH` to support `node -r nodejs-dashboard` required for full usage. [\#90]
+- *Internal*: Use SIGINT for Ctrl-c. [\#93]
+
 ## [v0.5.0] - 2019-11-21
 
 - **Breaking**: Update node engines to `8`+
@@ -57,6 +62,7 @@
 - *Internal*: Remove dependency on root-require, update repo url in package.json [\#2]
 - *Internal*: Test scaffolding and basic reporter integration test [\#3]
 
+[v0.5.0]: https://github.com/FormidableLabs/nodejs-dashboard/compare/v0.4.3...v0.5.0
 [v0.4.3]: https://github.com/FormidableLabs/nodejs-dashboard/compare/v0.4.1...v0.4.3
 [v0.4.1]: https://github.com/FormidableLabs/nodejs-dashboard/compare/v0.4.0...v0.4.1
 [v0.4.0]: https://github.com/FormidableLabs/nodejs-dashboard/compare/v0.3.0...v0.4.0
@@ -66,6 +72,8 @@
 [v0.1.2]: https://github.com/FormidableLabs/nodejs-dashboard/compare/v0.1.1...v0.1.2
 [v0.1.1]: https://github.com/FormidableLabs/nodejs-dashboard/compare/v0.1.0...v0.1.1
 
+[\#93]: https://github.com/FormidableLabs/nodejs-dashboard/pull/93
+[\#90]: https://github.com/FormidableLabs/nodejs-dashboard/issues/90
 [\#76]: https://github.com/FormidableLabs/nodejs-dashboard/pull/76
 [\#68]: https://github.com/FormidableLabs/nodejs-dashboard/pull/72
 [\#67]: https://github.com/FormidableLabs/nodejs-dashboard/pull/70

--- a/bin/nodejs-dashboard.js
+++ b/bin/nodejs-dashboard.js
@@ -75,9 +75,23 @@ process.env[config.PORT_KEY] = port;
 process.env[config.REFRESH_INTERVAL_KEY] = program.refreshinterval;
 process.env[config.BLOCKED_THRESHOLD_KEY] = program.eventdelay;
 
+// Enhance `NODE_PATH` to include the dashboard such that `require("nodejs-dashboard")`
+// works even if globally installed.
+// See: https://github.com/FormidableLabs/nodejs-dashboard/issues/90
+const IS_WIN = process.platform.indexOf("win") === 0;
+const DELIM = IS_WIN ? ";" : ":";
+const DASHBOARD_PATH = path.resolve(__dirname, "../..");
+const NODE_PATH = (process.env.NODE_PATH || "")
+  .split(DELIM)
+  .filter(Boolean)
+  .concat(DASHBOARD_PATH)
+  .join(DELIM);
 
 const child = spawn(command, args, {
-  env: process.env,
+  env: {
+    ...process.env,
+    NODE_PATH
+  },
   stdio: [null, null, null, null],
   detached: true
 });

--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -52,7 +52,7 @@ Dashboard.prototype._configureKeys = function () {
   // this key will be watched on the global screen
   this.screen.ignoreLocked = ["C-c"];
   this.screen.key("C-c", () => {
-    process.exit(0); // eslint-disable-line no-process-exit
+    process.kill(process.pid, "SIGINT");
   });
 
   // watch for key events on the main container; not the screen


### PR DESCRIPTION
- Add the `node_modules` directory from wherever `nodejs-dashboard` is installed to `NODE_PATH` so that the portion of the instructions `<SNIPPED> -- node -r nodejs-dashboard <SNIPPED>` works. Appreciate review from @AaronRobinson and @carbonrobot ! Fixes #90 
- Use SIGINT for Ctrl-c. Replaces and closes #93 Thanks for the original PR and appreciate review @joakimbeng

